### PR TITLE
feat(domain): Add Scheduling and Expense module entities

### DIFF
--- a/API_Banho_Tosa/Domain/Entities/AvailableService.cs
+++ b/API_Banho_Tosa/Domain/Entities/AvailableService.cs
@@ -10,5 +10,7 @@
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
         public DateTime? DeletedAt { get; private set; }
+
+        public ICollection<ServicePrice> ServicePrices { get; private set; } = new List<ServicePrice>();
     }
 }

--- a/API_Banho_Tosa/Domain/Entities/AvailableService.cs
+++ b/API_Banho_Tosa/Domain/Entities/AvailableService.cs
@@ -12,5 +12,6 @@
         public DateTime? DeletedAt { get; private set; }
 
         public ICollection<ServicePrice> ServicePrices { get; private set; } = new List<ServicePrice>();
+        public ICollection<ServiceItem> ServiceItems { get; private set; } = new List<ServiceItem>();
     }
 }

--- a/API_Banho_Tosa/Domain/Entities/AvailableService.cs
+++ b/API_Banho_Tosa/Domain/Entities/AvailableService.cs
@@ -1,0 +1,14 @@
+﻿namespace API_Banho_Tosa.Domain.Entities
+{
+    public class AvailableService
+    {
+        public int Id { get; private set; }
+        public Guid Uuid { get; private set; }
+        public string Description { get; private set; } = string.Empty;
+        public int? ServiceDurationMinutes { get; private set; }
+
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
+        public DateTime? DeletedAt { get; private set; }
+    }
+}

--- a/API_Banho_Tosa/Domain/Entities/PaymentStatus.cs
+++ b/API_Banho_Tosa/Domain/Entities/PaymentStatus.cs
@@ -4,5 +4,6 @@
     {
         public int Id { get; private set; }
         public string Description { get; private set; } = string.Empty;
+        public ICollection<Service> Services { get; private set; } = new List<Service>();
     }
 }

--- a/API_Banho_Tosa/Domain/Entities/PaymentStatus.cs
+++ b/API_Banho_Tosa/Domain/Entities/PaymentStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace API_Banho_Tosa.Domain.Entities
+{
+    public class PaymentStatus
+    {
+        public int Id { get; private set; }
+        public string Description { get; private set; } = string.Empty;
+    }
+}

--- a/API_Banho_Tosa/Domain/Entities/Pet.cs
+++ b/API_Banho_Tosa/Domain/Entities/Pet.cs
@@ -41,6 +41,8 @@ namespace API_Banho_Tosa.Domain.Entities
         public PetSize PetSize { get; private set; } = null!;
         public ICollection<Owner> Owners { get; } = new List<Owner>();
 
+        public ICollection<Service> Services = new List<Service>();
+
         private Pet() { }
 
         private Pet(string name, int breedId, int petSizeId, DateTime? birthDate)

--- a/API_Banho_Tosa/Domain/Entities/PetSize.cs
+++ b/API_Banho_Tosa/Domain/Entities/PetSize.cs
@@ -18,6 +18,7 @@ namespace API_Banho_Tosa.Domain.Entities
         public DateTime UpdatedAt { get; private set; }
 
         public HashSet<Pet> Pets { get; } = new HashSet<Pet>();
+        public ICollection<ServicePrice> ServicePrices { get; private set; }
 
         private PetSize() 
         {

--- a/API_Banho_Tosa/Domain/Entities/Service.cs
+++ b/API_Banho_Tosa/Domain/Entities/Service.cs
@@ -1,0 +1,28 @@
+﻿namespace API_Banho_Tosa.Domain.Entities
+{
+    public class Service
+    {
+        public int Id { get; private set; }
+        public Guid Uuid { get; private set; }
+        public DateTime ServiceDate { get; private set; }
+
+        public int PetId { get; private set; }
+        public Pet Pet { get; private set; } = null!;
+
+        public int ServiceStatusId { get; private set; }
+        public ServiceStatus ServiceStatus { get; private set; } = null!;
+
+        public int PaymentStatusId { get; private set; }
+        public PaymentStatus PaymentStatus { get; private set; } = null!;
+
+        public DateTime? PaymentDate { get; private set; }
+        public DateTime PaymentDueTime { get; private set; }
+        public decimal Subtotal { get; private set; }
+        public decimal AdditionalCharges { get; private set; }
+        public decimal DiscountValue { get; private set; }
+        public decimal FinalTotal { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
+        public DateTime? DeletedAt { get; private set; }
+    }
+}

--- a/API_Banho_Tosa/Domain/Entities/Service.cs
+++ b/API_Banho_Tosa/Domain/Entities/Service.cs
@@ -6,7 +6,7 @@
         public Guid Uuid { get; private set; }
         public DateTime ServiceDate { get; private set; }
 
-        public int PetId { get; private set; }
+        public Guid PetUuid { get; private set; }
         public Pet Pet { get; private set; } = null!;
 
         public int ServiceStatusId { get; private set; }

--- a/API_Banho_Tosa/Domain/Entities/Service.cs
+++ b/API_Banho_Tosa/Domain/Entities/Service.cs
@@ -24,5 +24,7 @@
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
         public DateTime? DeletedAt { get; private set; }
+
+        public ICollection<ServiceItem> ServiceItems { get; private set; } = new List<ServiceItem>();
     }
 }

--- a/API_Banho_Tosa/Domain/Entities/ServiceItem.cs
+++ b/API_Banho_Tosa/Domain/Entities/ServiceItem.cs
@@ -1,0 +1,19 @@
+﻿namespace API_Banho_Tosa.Domain.Entities
+{
+    public class ServiceItem
+    {
+        public int Id { get; private set; }
+
+        public int ServiceId { get; private set; }
+        public Service Service { get; private set; } = null!;
+
+        public int AvailableServiceId { get; private set; }
+        public AvailableService AvailableService { get; private set; } = null!;
+
+        public decimal PriceAtTheTime { get; private set; }
+        public int Quantity { get; private set; }
+
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
+    }
+}

--- a/API_Banho_Tosa/Domain/Entities/ServicePrice.cs
+++ b/API_Banho_Tosa/Domain/Entities/ServicePrice.cs
@@ -1,0 +1,15 @@
+﻿namespace API_Banho_Tosa.Domain.Entities
+{
+    public class ServicePrice
+    {
+        public int AvailableServiceId { get; private set; }
+        public AvailableService AvailableService { get; private set; } = null!;
+
+        public int PetSizeId { get; private set; }
+        public PetSize PetSize { get; private set; } = null!;
+
+        public decimal Price { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
+    }
+}

--- a/API_Banho_Tosa/Domain/Entities/ServiceStatus.cs
+++ b/API_Banho_Tosa/Domain/Entities/ServiceStatus.cs
@@ -4,5 +4,6 @@
     {
         public int Id { get; private set; }
         public string Description { get; private set; } = string.Empty;
+        public ICollection<Service> Services { get; private set; } = new List<Service>();
     }
 }

--- a/API_Banho_Tosa/Domain/Entities/ServiceStatus.cs
+++ b/API_Banho_Tosa/Domain/Entities/ServiceStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace API_Banho_Tosa.Domain.Entities
+{
+    public class ServiceStatus
+    {
+        public int Id { get; private set; }
+        public string Description { get; private set; } = string.Empty;
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/BanhoTosaContext.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/BanhoTosaContext.cs
@@ -133,25 +133,22 @@ namespace API_Banho_Tosa.Infrastructure.Persistence
 
             #region Pet builder
 
-            modelBuilder
-                .Entity<Pet>(pet =>
-                {
-                    pet.HasQueryFilter(p => p.DeletedAt == null);
-                });
+            modelBuilder.Entity<Pet>(pet =>
+            {
+                pet.HasQueryFilter(p => p.DeletedAt == null);
 
-            modelBuilder
-                .Entity<Pet>()
-                .HasMany(p => p.Owners)
-                .WithMany(o => o.Pets)
-                .UsingEntity<Dictionary<string, object>>(
-                    "pets_owners",
-                    j => j.HasOne<Owner>()
-                          .WithMany()
-                          .HasForeignKey("owner_id"),
-                    l => l.HasOne<Pet>()
-                          .WithMany()
-                          .HasForeignKey("pet_id")
-                );
+                pet.HasMany(p => p.Owners)
+                    .WithMany(o => o.Pets)
+                    .UsingEntity<Dictionary<string, object>>(
+                        "pets_owners",
+                        j => j.HasOne<Owner>()
+                                .WithMany()
+                                .HasForeignKey("owner_id"),
+                        l => l.HasOne<Pet>()
+                                .WithMany()
+                                .HasForeignKey("pet_id")
+                    );
+            });
 
             #endregion
         }

--- a/API_Banho_Tosa/Infrastructure/Persistence/BanhoTosaContext.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/BanhoTosaContext.cs
@@ -23,6 +23,8 @@ namespace API_Banho_Tosa.Infrastructure.Persistence
         {
             base.OnModelCreating(modelBuilder);
 
+            modelBuilder.ApplyConfigurationsFromAssembly(typeof(BanhoTosaContext).Assembly);
+
             #region Owner builder
 
             modelBuilder.Entity<Owner>(owner =>

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/AvailableServiceConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/AvailableServiceConfiguration.cs
@@ -1,0 +1,43 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
+{
+    public class AvailableServiceConfiguration : IEntityTypeConfiguration<AvailableService>
+    {
+        public void Configure(EntityTypeBuilder<AvailableService> builder)
+        {
+            builder.ToTable("available_services");
+
+            builder.Property(avs => avs.Id)
+                   .HasColumnName("available_service_id")
+                   .UseIdentityColumn();
+
+            builder.Property(avs => avs.Uuid)
+                   .HasColumnName("available_service_uuid")
+                   .IsRequired();
+
+            builder.Property(avs => avs.Description)
+                   .HasColumnName("description")
+                   .HasMaxLength(255)
+                   .IsRequired();
+
+            builder.Property(avs => avs.ServiceDurationMinutes)
+                   .HasColumnName("available_service_duration_minutes")
+                   .IsRequired(false);
+
+            builder.Property(avs => avs.CreatedAt)
+                   .HasColumnName("created_at")
+                   .IsRequired();
+
+            builder.Property(avs => avs.UpdatedAt)
+                   .HasColumnName("updated_at")
+                   .IsRequired();
+
+            builder.Property(avs => avs.DeletedAt)
+                   .HasColumnName("deleted_at")
+                   .IsRequired(false);
+        }
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/PaymentStatusConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/PaymentStatusConfiguration.cs
@@ -19,7 +19,8 @@ namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
 
             builder.Property(ps => ps.Description)
                    .HasColumnName("payment_status_description")
-                   .HasMaxLength(100);
+                   .HasMaxLength(100)
+                   .IsRequired();
         }
     }
 }

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/PaymentStatusConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/PaymentStatusConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
+{
+    public class PaymentStatusConfiguration : IEntityTypeConfiguration<PaymentStatus>
+    {
+        public void Configure(EntityTypeBuilder<PaymentStatus> builder)
+        {
+            builder.ToTable("payment_status");
+
+            builder.Property(ps => ps.Id)
+                   .HasColumnName("payment_status_id")
+                   .UseIdentityColumn();
+
+            builder.HasIndex(ps => ps.Description)
+                   .IsUnique();
+
+            builder.Property(ps => ps.Description)
+                   .HasColumnName("payment_status_description")
+                   .HasMaxLength(100);
+        }
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/PaymentStatusConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/PaymentStatusConfiguration.cs
@@ -21,6 +21,11 @@ namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
                    .HasColumnName("payment_status_description")
                    .HasMaxLength(100)
                    .IsRequired();
+
+            builder.HasMany(ps => ps.Services)
+                   .WithOne(s => s.PaymentStatus)
+                   .HasForeignKey(s => s.PaymentStatusId)
+                   .IsRequired();
         }
     }
 }

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
@@ -18,7 +18,7 @@ namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
                    .HasColumnName("service_date")
                    .IsRequired();
 
-            builder.Property(s => s.PetId)
+            builder.Property(s => s.PetUuid)
                    .HasColumnName("pet_id")
                    .IsRequired();
 
@@ -72,8 +72,13 @@ namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
 
             builder.HasOne(s => s.Pet)
                    .WithMany(p => p.Services)
-                   .HasForeignKey(s => s.PetId)
+                   .HasForeignKey(s => s.PetUuid)
                    .IsRequired();
+
+            builder.HasQueryFilter(s =>
+                s.DeletedAt == null &&
+                s.Pet.DeletedAt == null
+            );
         }
     }
 }

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
@@ -1,0 +1,79 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
+{
+    public class ServiceConfiguration : IEntityTypeConfiguration<Service>
+    {
+        public void Configure(EntityTypeBuilder<Service> builder)
+        {
+            builder.ToTable("services");
+
+            builder.Property(s => s.Id)
+                   .HasColumnName("service_id")
+                   .UseIdentityColumn();
+
+            builder.Property(s => s.ServiceDate)
+                   .HasColumnName("service_date")
+                   .IsRequired();
+
+            builder.Property(s => s.PetId)
+                   .HasColumnName("pet_id")
+                   .IsRequired();
+
+            builder.Property(s => s.ServiceStatusId)
+                   .HasColumnName("service_status_id")
+                   .IsRequired();
+
+            builder.Property(s => s.PaymentStatusId)
+                   .HasColumnName("payment_status_id")
+                   .IsRequired();
+
+            builder.Property(s => s.PaymentDate)
+                   .HasColumnName("payment_date")
+                   .IsRequired(false);
+
+            builder.Property(s => s.PaymentDueTime)
+                   .HasColumnName("payment_due_date")
+                   .IsRequired();
+
+            builder.Property(s => s.Subtotal)
+                   .HasColumnName("subtotal")
+                   .HasPrecision(10, 2)
+                   .IsRequired();
+
+            builder.Property(s => s.AdditionalCharges)
+                   .HasColumnName("additional_charges")
+                   .HasPrecision(10, 2)
+                   .IsRequired();
+
+            builder.Property(s => s.DiscountValue)
+                   .HasColumnName("discount_value")
+                   .HasPrecision(10, 2)
+                   .IsRequired();
+
+            builder.Property(s => s.FinalTotal)
+                   .HasColumnName("final_total")
+                   .HasPrecision(10, 2)
+                   .IsRequired();
+
+            builder.Property(s => s.CreatedAt)
+                   .HasColumnName("created_at")
+                   .IsRequired();
+
+            builder.Property(s => s.UpdatedAt)
+                   .HasColumnName("updated_at")
+                   .IsRequired();
+
+            builder.Property(s => s.DeletedAt)
+                   .HasColumnName("deleted_at")
+                   .IsRequired(false);
+
+            builder.HasOne(s => s.Pet)
+                   .WithMany(p => p.Services)
+                   .HasForeignKey(s => s.PetId)
+                   .IsRequired();
+        }
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceItemConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceItemConfiguration.cs
@@ -1,0 +1,53 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
+{
+    public class ServiceItemConfiguration : IEntityTypeConfiguration<ServiceItem>
+    {
+        public void Configure(EntityTypeBuilder<ServiceItem> builder)
+        {
+            builder.ToTable("service_items");
+
+            builder.Property(si => si.Id)
+                   .HasColumnName("service_item_id")
+                   .UseIdentityColumn();
+
+            builder.Property(si => si.ServiceId)
+                   .HasColumnName("service_id")
+                   .IsRequired();
+
+            builder.Property(si => si.AvailableServiceId)
+                   .HasColumnName("available_service")
+                   .IsRequired();
+
+            builder.Property(si => si.PriceAtTheTime)
+                   .HasColumnName("price_at_the_time")
+                   .HasPrecision(10, 2)
+                   .IsRequired();
+
+            builder.Property(si => si.Quantity)
+                   .HasColumnName("quantity")
+                   .IsRequired();
+
+            builder.Property(si => si.CreatedAt)
+                   .HasColumnName("created_at")
+                   .IsRequired();
+
+            builder.Property(si => si.UpdatedAt)
+                   .HasColumnName("updated_at")
+                   .IsRequired();
+
+            builder.HasOne(si => si.Service)
+                   .WithMany(s => s.ServiceItems)
+                   .HasForeignKey(si => si.ServiceId)
+                   .IsRequired();
+
+            builder.HasOne(si => si.AvailableService)
+                   .WithMany(avs => avs.ServiceItems)
+                   .HasForeignKey(si => si.AvailableServiceId)
+                   .IsRequired();
+        }
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceItemConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceItemConfiguration.cs
@@ -48,6 +48,11 @@ namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
                    .WithMany(avs => avs.ServiceItems)
                    .HasForeignKey(si => si.AvailableServiceId)
                    .IsRequired();
+
+            builder.HasQueryFilter(
+                si => si.Service.DeletedAt == null &&
+                si.Service.Pet.DeletedAt == null
+            );
         }
     }
 }

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServicePriceConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServicePriceConfiguration.cs
@@ -1,0 +1,43 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
+{
+    public class ServicePriceConfiguration : IEntityTypeConfiguration<ServicePrice>
+    {
+        public void Configure(EntityTypeBuilder<ServicePrice> builder)
+        {
+            builder.ToTable("service_prices");
+
+            builder.HasKey(sp => new { sp.AvailableServiceId, sp.PetSizeId });
+
+            builder.HasOne(sp => sp.AvailableService)
+                   .WithMany(avs => avs.ServicePrices)
+                   .HasForeignKey(sp => sp.AvailableServiceId);
+
+            builder.HasOne(sp => sp.PetSize)
+                   .WithMany(ps => ps.ServicePrices)
+                   .HasForeignKey(sp => sp.PetSizeId);
+
+            builder.Property(sp => sp.AvailableServiceId)
+                   .HasColumnName("available_service_id");
+
+            builder.Property(sp => sp.PetSizeId)
+                   .HasColumnName("pet_size_id");
+
+            builder.Property(sp => sp.Price)
+                   .HasColumnName("service_price")
+                   .HasPrecision(10, 2)
+                   .IsRequired();
+
+            builder.Property(sp => sp.CreatedAt)
+                   .HasColumnName("created_at")
+                   .IsRequired();
+
+            builder.Property(sp => sp.UpdatedAt)
+                   .HasColumnName("updated_at")
+                   .IsRequired();
+        }
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceStatusConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceStatusConfiguration.cs
@@ -21,6 +21,11 @@ namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
                    .HasColumnName("service_status_description")
                    .HasMaxLength(100)
                    .IsRequired();
+
+            builder.HasMany(ss => ss.Services)
+                   .WithOne(s => s.ServiceStatus)
+                   .HasForeignKey(s => s.ServiceStatusId)
+                   .IsRequired();
         }
     }
 }

--- a/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceStatusConfiguration.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Configurations/ServiceStatusConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Configurations
+{
+    public class ServiceStatusConfiguration : IEntityTypeConfiguration<ServiceStatus>
+    {
+        public void Configure(EntityTypeBuilder<ServiceStatus> builder)
+        {
+            builder.ToTable("service_status");
+
+            builder.Property(ss => ss.Id)
+                   .HasColumnName("service_status_id")
+                   .UseIdentityColumn();
+
+            builder.HasIndex(ss => ss.Description)
+                   .IsUnique();
+
+            builder.Property(ss => ss.Description)
+                   .HasColumnName("service_status_description")
+                   .HasMaxLength(100)
+                   .IsRequired();
+        }
+    }
+}

--- a/API_Banho_Tosa/Migrations/20251113023550_AddMissingEntities.Designer.cs
+++ b/API_Banho_Tosa/Migrations/20251113023550_AddMissingEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API_Banho_Tosa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API_Banho_Tosa.Migrations
 {
     [DbContext(typeof(BanhoTosaContext))]
-    partial class BanhoTosaContextModelSnapshot : ModelSnapshot
+    [Migration("20251113023550_AddMissingEntities")]
+    partial class AddMissingEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API_Banho_Tosa/Migrations/20251113023550_AddMissingEntities.cs
+++ b/API_Banho_Tosa/Migrations/20251113023550_AddMissingEntities.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace API_Banho_Tosa.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMissingEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "available_services",
+                columns: table => new
+                {
+                    available_service_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    available_service_uuid = table.Column<Guid>(type: "uuid", nullable: false),
+                    description = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    available_service_duration_minutes = table.Column<int>(type: "integer", nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_available_services", x => x.available_service_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "payment_status",
+                columns: table => new
+                {
+                    payment_status_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    payment_status_description = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_payment_status", x => x.payment_status_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "service_status",
+                columns: table => new
+                {
+                    service_status_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    service_status_description = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_service_status", x => x.service_status_id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "service_prices",
+                columns: table => new
+                {
+                    available_service_id = table.Column<int>(type: "integer", nullable: false),
+                    pet_size_id = table.Column<int>(type: "integer", nullable: false),
+                    service_price = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_service_prices", x => new { x.available_service_id, x.pet_size_id });
+                    table.ForeignKey(
+                        name: "FK_service_prices_available_services_available_service_id",
+                        column: x => x.available_service_id,
+                        principalTable: "available_services",
+                        principalColumn: "available_service_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_service_prices_pet_sizes_pet_size_id",
+                        column: x => x.pet_size_id,
+                        principalTable: "pet_sizes",
+                        principalColumn: "pet_size_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "services",
+                columns: table => new
+                {
+                    service_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Uuid = table.Column<Guid>(type: "uuid", nullable: false),
+                    service_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    pet_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    service_status_id = table.Column<int>(type: "integer", nullable: false),
+                    payment_status_id = table.Column<int>(type: "integer", nullable: false),
+                    payment_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    payment_due_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    subtotal = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    additional_charges = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    discount_value = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    final_total = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    deleted_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_services", x => x.service_id);
+                    table.ForeignKey(
+                        name: "FK_services_payment_status_payment_status_id",
+                        column: x => x.payment_status_id,
+                        principalTable: "payment_status",
+                        principalColumn: "payment_status_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_services_pets_pet_id",
+                        column: x => x.pet_id,
+                        principalTable: "pets",
+                        principalColumn: "pet_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_services_service_status_service_status_id",
+                        column: x => x.service_status_id,
+                        principalTable: "service_status",
+                        principalColumn: "service_status_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "service_items",
+                columns: table => new
+                {
+                    service_item_id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    service_id = table.Column<int>(type: "integer", nullable: false),
+                    available_service = table.Column<int>(type: "integer", nullable: false),
+                    price_at_the_time = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    quantity = table.Column<int>(type: "integer", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_service_items", x => x.service_item_id);
+                    table.ForeignKey(
+                        name: "FK_service_items_available_services_available_service",
+                        column: x => x.available_service,
+                        principalTable: "available_services",
+                        principalColumn: "available_service_id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_service_items_services_service_id",
+                        column: x => x.service_id,
+                        principalTable: "services",
+                        principalColumn: "service_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_payment_status_payment_status_description",
+                table: "payment_status",
+                column: "payment_status_description",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_service_items_available_service",
+                table: "service_items",
+                column: "available_service");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_service_items_service_id",
+                table: "service_items",
+                column: "service_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_service_prices_pet_size_id",
+                table: "service_prices",
+                column: "pet_size_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_service_status_service_status_description",
+                table: "service_status",
+                column: "service_status_description",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_services_payment_status_id",
+                table: "services",
+                column: "payment_status_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_services_pet_id",
+                table: "services",
+                column: "pet_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_services_service_status_id",
+                table: "services",
+                column: "service_status_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "service_items");
+
+            migrationBuilder.DropTable(
+                name: "service_prices");
+
+            migrationBuilder.DropTable(
+                name: "services");
+
+            migrationBuilder.DropTable(
+                name: "available_services");
+
+            migrationBuilder.DropTable(
+                name: "payment_status");
+
+            migrationBuilder.DropTable(
+                name: "service_status");
+        }
+    }
+}


### PR DESCRIPTION
This PR establishes the complete database schema for the application's MVP by adding all remaining domain entities for the "Scheduling" and "Expense" modules.

With this foundation in place, the project is now ready for the development of the vertical slices (repositories, services, controllers) for each new feature.

### Key Additions:

* **Scheduling Module Entities:**
    * `ServiceStatus` (Lookup table)
    * `PaymentStatus` (Lookup table)
    * `AvailableService` (The "menu" of services offered)
    * `ServicePrice` (Junction table with composite key for `AvailableServiceId` + `PetSizeId`)
    * `Service` (The main appointment entity)
    * `ServiceItem` (Line items for a `Service`)

* **Expense Module Entities:**
    * `ExpenseCategory` (Lookup table)
    * `Expense`

### Architecture & Persistence:

* **`IEntityTypeConfiguration` Pattern:** All new entity configurations are encapsulated in their own dedicated classes, keeping the `DbContext.OnModelCreating` clean and organized.
* **Relationship Mapping:** Configured all new one-to-many and composite key relationships.
* **Soft-Delete Integrity:** Resolved the `PendingModelChangesWarning` by adding cascaded `HasQueryFilter` to the `Service` and `ServiceItem` entities. This ensures that any queries for services or service items are correctly filtered if the parent `Pet` is soft-deleted.
* **New Migration:** This PR includes the new database migration (`AddMissingEntities`) that applies this entire schema to the database.