### PR TITLE
feat(pets): Implement Pet CRUD and Owner association

### DIFF
--- a/API_Banho_Tosa/API/Controllers/PetController.cs
+++ b/API_Banho_Tosa/API/Controllers/PetController.cs
@@ -1,0 +1,79 @@
+﻿using API_Banho_Tosa.Application.Pets.DTOs;
+using API_Banho_Tosa.Application.Pets.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API_Banho_Tosa.API.Controllers
+{
+    [Route("api/pets")]
+    [ApiController]
+    public class PetController(IPetService petService) : ControllerBase
+    {
+        [HttpGet]
+        public async Task<IActionResult> SearchPets([FromQuery] PetFilterQuery filter)
+        {
+            var response = await petService.SearchPetsAsync(filter);
+            return Ok(response);
+        }
+
+        [HttpGet("deleted")]
+        public async Task<IActionResult> SearchDeletedPets([FromQuery] PetFilterQuery filter)
+        {
+            var response = await petService.SearchDeletedPetsAsync(filter);
+            return Ok(response);
+        }
+
+        [HttpGet("{id:guid}", Name = "GetPetById")]
+        public async Task<IActionResult> GetPetById([FromRoute] Guid id)
+        {
+            var response = await petService.GetPetByIdAsync(id);
+            return Ok(response);
+        }
+
+        [HttpDelete("{id:guid}")]
+        public async Task<IActionResult> DeletePet([FromRoute] Guid id)
+        {
+            await petService.DeletePetAsync(id);
+            return NoContent();
+        }
+
+        [HttpPut("{id:guid}")]
+        public async Task<IActionResult> UpdatePet([FromRoute] Guid id, [FromBody] UpdatePetRequest request)
+        {
+            var response = await petService.UpdatePetAsync(id, request);
+            return Ok(response);
+        }
+
+        [HttpPatch("{id:guid}/reactivate")]
+        public async Task<IActionResult> ReactivatePet([FromRoute] Guid id)
+        {
+            await petService.ReactivatePetAsync(id);
+            return NoContent();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreatePet([FromBody] CreatePetRequest request)
+        {
+            var response = await petService.CreatePetAsync(request);
+            return CreatedAtRoute(
+                routeName: nameof(GetPetById),
+                routeValues: new { id = response.Id },
+                value: response
+            );
+        }
+
+        [HttpPost("{id:guid}/owners")]
+        public async Task<IActionResult> SetNewOwner([FromRoute] Guid id, [FromBody] SetOwnerRequest request)
+        {
+            var response = await petService.SetNewOwnerAsync(id, request);
+            return Ok(response);
+        }
+
+        [HttpDelete("{petId:guid}/owners/{ownerId:guid}")]
+        public async Task<IActionResult> RemoveOwner([FromRoute] Guid petId, [FromRoute] Guid ownerId)
+        {
+            await petService.RemoveOwnerAsync(petId, ownerId);
+            return NoContent();
+        }
+    }
+}

--- a/API_Banho_Tosa/Application/Pets/DTOs/CreatePetRequest.cs
+++ b/API_Banho_Tosa/Application/Pets/DTOs/CreatePetRequest.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace API_Banho_Tosa.Application.Pets.DTOs
+{
+    public record CreatePetRequest
+    (
+        [property: JsonPropertyName("name")]
+        string Name,
+
+        [property: JsonPropertyName("breed_id")]
+        int BreedId,
+
+        [property: JsonPropertyName("pet_size_id")]
+        int PetSizeId,
+
+        [property: JsonPropertyName("owner_id")]
+        Guid OwnerId,
+
+        [property: JsonPropertyName("birth_date")]
+        DateTime? BirthDate
+    );
+}

--- a/API_Banho_Tosa/Application/Pets/DTOs/PetFilterQuery.cs
+++ b/API_Banho_Tosa/Application/Pets/DTOs/PetFilterQuery.cs
@@ -1,0 +1,11 @@
+﻿namespace API_Banho_Tosa.Application.Pets.DTOs
+{
+    public record PetFilterQuery
+    (
+        string? PetName, 
+        
+        string? OwnerName, 
+        
+        Guid? OwnerId
+    );
+}

--- a/API_Banho_Tosa/Application/Pets/DTOs/PetResponse.cs
+++ b/API_Banho_Tosa/Application/Pets/DTOs/PetResponse.cs
@@ -1,0 +1,31 @@
+﻿using API_Banho_Tosa.Application.Breeds.DTOs;
+using API_Banho_Tosa.Application.Owners.DTOs;
+using API_Banho_Tosa.Application.PetSizes.DTOs;
+using System.Text.Json.Serialization;
+
+namespace API_Banho_Tosa.Application.Pets.DTOs
+{
+    public record PetResponse
+    (
+        [property: JsonPropertyName("id")]
+        Guid Id,
+
+        [property: JsonPropertyName("name")]
+        string Name,
+
+        [property: JsonPropertyName("latest_visit")]
+        DateTime? LatestVisit,
+
+        [property: JsonPropertyName("birth_date")]
+        DateTime? BirthDate,
+
+        [property: JsonPropertyName("breed")]
+        BreedResponse Breed,
+
+        [property: JsonPropertyName("pet_size")]
+        PetSizeResponse PetSize,
+
+        [property: JsonPropertyName("owners")]
+        IEnumerable<OwnerResponse> Owners
+    );
+}

--- a/API_Banho_Tosa/Application/Pets/DTOs/SetOwnerRequest.cs
+++ b/API_Banho_Tosa/Application/Pets/DTOs/SetOwnerRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace API_Banho_Tosa.Application.Pets.DTOs
+{
+    public record SetOwnerRequest
+    (
+        [property: JsonPropertyName("owner_id")]
+        Guid OwnerId
+    );
+}

--- a/API_Banho_Tosa/Application/Pets/DTOs/UpdatePetRequest.cs
+++ b/API_Banho_Tosa/Application/Pets/DTOs/UpdatePetRequest.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace API_Banho_Tosa.Application.Pets.DTOs
+{
+    public record UpdatePetRequest
+    (
+        [property: JsonPropertyName("name")]
+        string Name,
+
+        [property: JsonPropertyName("breed_id")]
+        int BreedId,
+
+        [property: JsonPropertyName("pet_size_id")]
+        int PetSizeId,
+
+        [property: JsonPropertyName("latest_visit")]
+        DateTime? LatestVisit,
+
+        [property: JsonPropertyName("birth_date")]
+        DateTime? BirthDate
+    );
+}

--- a/API_Banho_Tosa/Application/Pets/Mappers/PetMapper.cs
+++ b/API_Banho_Tosa/Application/Pets/Mappers/PetMapper.cs
@@ -1,0 +1,24 @@
+﻿using API_Banho_Tosa.Application.Breeds.Mappers;
+using API_Banho_Tosa.Application.Owners.Mappers;
+using API_Banho_Tosa.Application.Pets.DTOs;
+using API_Banho_Tosa.Application.PetSizes.Mappers;
+using API_Banho_Tosa.Domain.Entities;
+
+namespace API_Banho_Tosa.Application.Pets.Mappers
+{
+    public static class PetMapper
+    {
+        public static PetResponse ToResponse(this Pet pet)
+        {
+            return new PetResponse(
+                pet.Id,
+                pet.Name,
+                pet.LatestVisit,
+                pet.BirthDate,
+                pet.Breed.ToResponseDto(),
+                pet.PetSize.ToResponse(),
+                pet.Owners.Select(o => o.MapToResponse())
+            );
+        }
+    }
+}

--- a/API_Banho_Tosa/Application/Pets/Services/IPetService.cs
+++ b/API_Banho_Tosa/Application/Pets/Services/IPetService.cs
@@ -1,0 +1,18 @@
+﻿using API_Banho_Tosa.Application.Pets.DTOs;
+
+namespace API_Banho_Tosa.Application.Pets.Services
+{
+    public interface IPetService
+    {
+        Task<PetResponse> CreatePetAsync(CreatePetRequest request);
+        Task<PetResponse> UpdatePetAsync(Guid id, UpdatePetRequest request);
+        Task<PetResponse> GetPetByIdAsync(Guid id);
+        Task<PetResponse> SetNewOwnerAsync(Guid id, SetOwnerRequest request);
+        Task RemoveOwnerAsync(Guid petId, Guid ownerId);
+        Task DeletePetAsync(Guid id);
+        Task ReactivatePetAsync(Guid id);
+
+        Task<IEnumerable<PetResponse>> SearchPetsAsync(PetFilterQuery filter);
+        Task<IEnumerable<PetResponse>> SearchDeletedPetsAsync(PetFilterQuery filter);
+    }
+}

--- a/API_Banho_Tosa/Application/Pets/Services/PetService.cs
+++ b/API_Banho_Tosa/Application/Pets/Services/PetService.cs
@@ -1,0 +1,191 @@
+﻿using API_Banho_Tosa.Application.Pets.DTOs;
+using API_Banho_Tosa.Application.Pets.Mappers;
+using API_Banho_Tosa.Domain.Entities;
+using API_Banho_Tosa.Domain.Interfaces;
+
+namespace API_Banho_Tosa.Application.Pets.Services
+{
+    public class PetService(
+        IPetRepository petRepository,
+        IBreedRepository breedRepository,
+        IPetSizeRepository petSizeRepository,
+        IOwnerRepository ownerRepository) : IPetService
+    {
+        public async Task<PetResponse> CreatePetAsync(CreatePetRequest request)
+        {
+            var breed = await breedRepository.GetBreedByIdAsync(request.BreedId);
+            var petSize = await petSizeRepository.GetPetSizeByIdAsync(request.PetSizeId);
+            var owner = await ownerRepository.GetOwnerByUuidAsync(request.OwnerId);
+
+            var errors = new List<string>();
+
+            if (breed is null)
+            {
+                errors.Add($"Breed with ID '{request.BreedId}' doesn't exist.");
+            }
+            if (petSize is null)
+            {
+                errors.Add($"Pet size with ID '{request.PetSizeId}' doesn't exist.");
+            }
+            if (owner is null)
+            {
+                errors.Add("Owner defined doesn't exist.");
+            }
+
+            if (errors.Count > 0)
+            {
+                throw new KeyNotFoundException(string.Join(" | ", errors));
+            }
+
+            var pet = Pet.Create(request.Name, request.BreedId, request.PetSizeId, request.BirthDate);
+            pet.Owners.Add(owner!);
+
+            petRepository.AddPet(pet);
+            await petRepository.SaveChangesAsync();
+
+            pet.SetBreed(breed!);
+            pet.SetPetSize(petSize!);
+
+            return pet.ToResponse();
+        }
+
+        public async Task<PetResponse> GetPetByIdAsync(Guid id)
+        {
+            var pet = await petRepository.GetPetByIdAsync(id);
+
+            if (pet is null)
+            {
+                throw new KeyNotFoundException("Pet doesn't exist.");
+            }
+
+            return pet.ToResponse();
+        }
+
+        public async Task<PetResponse> UpdatePetAsync(Guid id, UpdatePetRequest request)
+        {
+            var pet = await petRepository.GetPetByIdAsync(id);
+
+            if (pet is null)
+            {
+                throw new KeyNotFoundException("Pet doesn't exist.");
+            }
+
+            var errors = new List<string>();
+
+            Breed? newBreed = null;
+            PetSize? newPetSize = null;
+
+            // --- FASE 1: VALIDAÇÃO (Apenas leitura) ---
+
+            if (pet.BreedId != request.BreedId)
+            {
+                newBreed = await breedRepository.GetBreedByIdAsync(request.BreedId);
+                if (newBreed is null) errors.Add($"Breed with ID '{request.BreedId}' doesn't exist.");
+            }
+
+            if (pet.PetSizeId != request.PetSizeId)
+            {
+                newPetSize = await petSizeRepository.GetPetSizeByIdAsync(request.PetSizeId);
+                if (newPetSize is null) errors.Add($"Pet size with ID '{request.PetSizeId}' doesn't exist.");
+            }
+
+            if (errors.Count > 0) throw new KeyNotFoundException(string.Join(" | ", errors));
+
+            // --- FASE 2: EXECUÇÃO (Alteração de estado) ---
+
+            // Agora que sabemos que tudo é válido, aplicamos as mudanças
+            if (newBreed != null) pet.SetBreed(newBreed);
+            if (newPetSize != null) pet.SetPetSize(newPetSize);
+
+            pet.Update(request.Name, request.BreedId, request.PetSizeId, request.LatestVisit, request.BirthDate);
+            await petRepository.SaveChangesAsync();
+
+            return pet.ToResponse();
+        }
+
+        public async Task DeletePetAsync(Guid id)
+        {
+            var pet = await petRepository.GetPetByIdAsync(id);
+
+            if (pet is null)
+            {
+                throw new KeyNotFoundException("Pet doesn't exist.");
+            }
+
+            pet.Delete();
+            await petRepository.SaveChangesAsync();
+        }
+
+        public async Task ReactivatePetAsync(Guid id)
+        {
+            var pet = await petRepository.GetDeletedPetByIdAsync(id);
+
+            if (pet is null)
+            {
+                throw new KeyNotFoundException("Pet doesn't exist.");
+            }
+
+            pet.Reactivate();
+            await petRepository.SaveChangesAsync();
+        }
+
+        public async Task<IEnumerable<PetResponse>> SearchPetsAsync(PetFilterQuery filter)
+        {
+            var pets = await petRepository.SearchPetsAsync(filter.PetName, filter.OwnerName, filter.OwnerId);
+            return pets.Select(p => p.ToResponse());
+        }
+
+        public async Task<IEnumerable<PetResponse>> SearchDeletedPetsAsync(PetFilterQuery filter)
+        {
+            var pets = await petRepository.SearchDeletedPetsAsync(filter.PetName, filter.OwnerName, filter.OwnerId);
+            return pets.Select(p => p.ToResponse());
+        }
+
+        public async Task<PetResponse> SetNewOwnerAsync(Guid id, SetOwnerRequest request)
+        {
+            var pet = await petRepository.GetPetByIdAsync(id);
+
+            if (pet is null)
+            {
+                throw new KeyNotFoundException("Pet doesn't exist.");
+            }
+
+            var owner = await ownerRepository.GetOwnerByUuidAsync(request.OwnerId);
+
+            if (owner is null)
+            {
+                throw new KeyNotFoundException("Defined owner doesn't exist.");
+            }
+
+            var ownerAlreadyLinked = pet.Owners.Any(o => o.Uuid == request.OwnerId);
+
+            if (ownerAlreadyLinked)
+            {
+                throw new InvalidOperationException("Owner already linked.");
+            }
+
+            pet.Owners.Add(owner);
+            await petRepository.SaveChangesAsync();
+
+            return pet.ToResponse();
+        }
+
+        public async Task RemoveOwnerAsync(Guid petId, Guid ownerId)
+        {
+            var pet = await petRepository.GetPetByIdAsync(petId);
+
+            if (pet is null) throw new KeyNotFoundException("Pet doesn't exist.");
+
+            var ownerToRemove = pet.Owners.FirstOrDefault(o => o.Uuid == ownerId);
+
+            if (ownerToRemove is null)
+            {
+                throw new KeyNotFoundException("This owner is not linked to this pet.");
+            }
+
+            pet.Owners.Remove(ownerToRemove);
+
+            await petRepository.SaveChangesAsync();
+        }
+    }
+}

--- a/API_Banho_Tosa/Domain/Entities/Pet.cs
+++ b/API_Banho_Tosa/Domain/Entities/Pet.cs
@@ -48,23 +48,35 @@ namespace API_Banho_Tosa.Domain.Entities
         private Pet(string name, int breedId, int petSizeId, DateTime? birthDate)
         {
             ValidateName(name);
-            if (breedId <= 0) throw new ArgumentException("Breed ID is required.");
-            if (petSizeId <= 0) throw new ArgumentException("Pet Size ID is required.");
+            if (breedId <= 0) throw new ArgumentException($"Breed ID {breedId} is invalid. Must be a value greater than 0.");
+            if (petSizeId <= 0) throw new ArgumentException($"Pet Size ID {petSizeId} is invalid. Must be a value greater than 0.");
 
             this.Id = Guid.CreateVersion7();
-            this.Name = name;
+            this.Name = name.Trim();
             this.BreedId = breedId;
             this.PetSizeId = petSizeId;
             this.BirthDate = birthDate;
 
             var now = DateTime.UtcNow;
             this.CreatedAt = now;
-            this.DeletedAt = now;
+            this.UpdatedAt = now;
         }
 
         public static Pet Create(string name, int breedId, int petSizeId, DateTime? birthDate)
         {
             return new Pet(name, breedId, petSizeId, birthDate);
+        }
+
+        public void SetBreed(Breed breed)
+        {
+            this.BreedId = breed.Id;
+            this.Breed = breed;
+        }
+
+        public void SetPetSize(PetSize petSize)
+        {
+            this.PetSizeId = petSize.Id;
+            this.PetSize = petSize;
         }
 
         private int? CalculateAge()
@@ -88,6 +100,11 @@ namespace API_Banho_Tosa.Domain.Entities
 
         public void Delete()
         {
+            if (this.IsDeleted())
+            {
+                throw new InvalidOperationException("Pet already deleted.");
+            }
+
             this.DeletedAt = DateTime.UtcNow;
             MarkAsUpdated();
         }
@@ -103,6 +120,34 @@ namespace API_Banho_Tosa.Domain.Entities
             {
                 throw new ArgumentException("The pet name cannot be null or empty.");
             }
+        }
+
+        public void Update(string name, int breedId, int petSizeId, DateTime? latestVisit, DateTime? birthDate)
+        {
+            ValidateName(name);
+            this.Name = name;
+            this.BreedId = breedId;
+            this.PetSizeId = petSizeId;
+            this.LatestVisit = latestVisit;
+            this.BirthDate = birthDate;
+
+            this.MarkAsUpdated();
+        }
+
+        public void Reactivate()
+        {
+            if (!this.IsDeleted())
+            {
+                throw new InvalidOperationException("Pet already active.");
+            }
+
+            this.DeletedAt = null;
+            this.MarkAsUpdated();
+        }
+
+        private bool IsDeleted()
+        {
+            return this.DeletedAt.HasValue;
         }
     }
 }

--- a/API_Banho_Tosa/Domain/Interfaces/IPetRepository.cs
+++ b/API_Banho_Tosa/Domain/Interfaces/IPetRepository.cs
@@ -1,0 +1,14 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+
+namespace API_Banho_Tosa.Domain.Interfaces
+{
+    public interface IPetRepository
+    {
+        void AddPet(Pet pet);
+        Task<Pet?> GetPetByIdAsync(Guid id);
+        Task<IEnumerable<Pet>> SearchPetsAsync(string? petName, string? ownerName, Guid? ownerId);
+        Task<IEnumerable<Pet>> SearchDeletedPetsAsync(string? petName, string? ownerName, Guid? ownerId);
+        Task<int> SaveChangesAsync();
+        Task<Pet?> GetDeletedPetByIdAsync(Guid id);
+    }
+}

--- a/API_Banho_Tosa/Infrastructure/Persistence/BanhoTosaContext.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/BanhoTosaContext.cs
@@ -25,6 +25,8 @@ namespace API_Banho_Tosa.Infrastructure.Persistence
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.HasPostgresExtension("unaccent");
+
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.ApplyConfigurationsFromAssembly(typeof(BanhoTosaContext).Assembly);

--- a/API_Banho_Tosa/Infrastructure/Persistence/Repositories/PetRepository.cs
+++ b/API_Banho_Tosa/Infrastructure/Persistence/Repositories/PetRepository.cs
@@ -1,0 +1,110 @@
+﻿using API_Banho_Tosa.Domain.Entities;
+using API_Banho_Tosa.Domain.Interfaces;
+using Microsoft.AspNetCore.Mvc.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+
+namespace API_Banho_Tosa.Infrastructure.Persistence.Repositories
+{
+    public class PetRepository(BanhoTosaContext context) : IPetRepository
+    {
+        public void AddPet(Pet pet)
+        {
+            context.Pets.Add(pet);
+        }
+
+        public async Task<Pet?> GetPetByIdAsync(Guid id)
+        {
+            return await context.Pets
+                .Include(p => p.Breed)
+                    .ThenInclude(b => b.AnimalType)
+                .Include(p => p.PetSize)
+                .Include(p => p.Owners)
+                .FirstOrDefaultAsync(p => p.Id == id);
+        }
+
+        public async Task<int> SaveChangesAsync()
+        {
+            return await context.SaveChangesAsync();
+        }
+        
+        public async Task<IEnumerable<Pet>> SearchPetsAsync(string? petName, string? ownerName, Guid? ownerId)
+        {
+            var query = context.Pets
+                .AsNoTracking()
+                .Include(p => p.Breed)
+                    .ThenInclude(b => b.AnimalType)
+                .Include(p => p.PetSize)
+                .Include(p => p.Owners)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(petName))
+            {
+                query = query.Where(p => 
+                    EF.Functions.ILike(
+                        EF.Functions.Unaccent(p.Name),
+                        EF.Functions.Unaccent($"{petName}%")
+                    )
+                );
+            }
+
+            if (!string.IsNullOrWhiteSpace(ownerName))
+            {
+                query = query.Where(p => p.Owners.Any(o => 
+                    EF.Functions.ILike(
+                        EF.Functions.Unaccent(o.Name),
+                        EF.Functions.Unaccent($"{ownerName}%")
+                    ))
+                );
+            }
+
+            if (ownerId.HasValue)
+            {
+                query = query.Where(p => p.Owners.Any(o => o.Uuid == ownerId.Value));
+            }
+
+            return await query.ToListAsync();
+        }
+
+        public async Task<IEnumerable<Pet>> SearchDeletedPetsAsync(string? petName, string? ownerName, Guid? ownerId)
+        {
+            var query = context.Pets
+                .AsNoTracking()
+                .IgnoreQueryFilters()
+                .Where(p => p.DeletedAt != null)
+                .Include(p => p.Breed)
+                    .ThenInclude(b => b.AnimalType)
+                .Include(p => p.PetSize)
+                .Include(p => p.Owners)
+                .AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(petName))
+            {
+                query = query.Where(p => EF.Functions.ILike(p.Name, $"{petName}%"));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ownerName))
+            {
+                query = query.Where(p => p.Owners.Any(o => EF.Functions.ILike(o.Name, $"{ownerName}%")));
+            }
+
+            if (ownerId.HasValue)
+            {
+                query = query.Where(p => p.Owners.Any(o => o.Uuid == ownerId.Value));
+            }
+
+            return await query.ToListAsync();
+        }
+
+        public async Task<Pet?> GetDeletedPetByIdAsync(Guid id)
+        {
+            return await context.Pets
+                .IgnoreQueryFilters()
+                .Where(p => p.DeletedAt != null)
+                .Include(p => p.Breed)
+                    .ThenInclude(b => b.AnimalType)
+                .Include(p => p.PetSize)
+                .Include(p => p.Owners)
+                .FirstOrDefaultAsync(p => p.Id == id);
+        }
+    }
+}

--- a/API_Banho_Tosa/Migrations/20251126003023_EnableUnaccentExtension.Designer.cs
+++ b/API_Banho_Tosa/Migrations/20251126003023_EnableUnaccentExtension.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using API_Banho_Tosa.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace API_Banho_Tosa.Migrations
 {
     [DbContext(typeof(BanhoTosaContext))]
-    partial class BanhoTosaContextModelSnapshot : ModelSnapshot
+    [Migration("20251126003023_EnableUnaccentExtension")]
+    partial class EnableUnaccentExtension
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/API_Banho_Tosa/Migrations/20251126003023_EnableUnaccentExtension.cs
+++ b/API_Banho_Tosa/Migrations/20251126003023_EnableUnaccentExtension.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace API_Banho_Tosa.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnableUnaccentExtension : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_services_service_status_service_status_id",
+                table: "services");
+
+            migrationBuilder.RenameColumn(
+                name: "Uuid",
+                table: "services",
+                newName: "service_uuid");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:unaccent", ",,");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_services_service_status_service_status_id",
+                table: "services",
+                column: "service_status_id",
+                principalTable: "service_status",
+                principalColumn: "service_status_id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_services_service_status_service_status_id",
+                table: "services");
+
+            migrationBuilder.RenameColumn(
+                name: "service_uuid",
+                table: "services",
+                newName: "Uuid");
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:PostgresExtension:unaccent", ",,");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_services_service_status_service_status_id",
+                table: "services",
+                column: "service_status_id",
+                principalTable: "service_status",
+                principalColumn: "service_status_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/API_Banho_Tosa/Program.cs
+++ b/API_Banho_Tosa/Program.cs
@@ -7,6 +7,7 @@ using API_Banho_Tosa.Application.Breeds.Services;
 using API_Banho_Tosa.Application.Common.Interfaces;
 using API_Banho_Tosa.Application.Owners.Services;
 using API_Banho_Tosa.Application.PaymentStatuses.Services;
+using API_Banho_Tosa.Application.Pets.Services;
 using API_Banho_Tosa.Application.PetSizes.Services;
 using API_Banho_Tosa.Application.ServicePrices.Services;
 using API_Banho_Tosa.Application.ServiceStatuses.Services;
@@ -215,6 +216,9 @@ namespace API_Banho_Tosa
 
             builder.Services.AddScoped<IServicePriceRepository, ServicePriceRepository>();
             builder.Services.AddScoped<IServicePriceService, ServicePriceService>();
+
+            builder.Services.AddScoped<IPetRepository, PetRepository>();
+            builder.Services.AddScoped<IPetService, PetService>();
         }
     }
 }


### PR DESCRIPTION
This PR implements the Pet management module, one of the core pillars of the system.

**Features:**
* Full CRUD for Pets.
* Automatic age calculation (`Age`) without database persistence.
* Many-to-Many relationship management between `Pets` and `Owners`.
* Endpoints to add and remove owners from an existing pet.
* Filtered search by pet name and owner name.

**Technical Details:**
* The `PetRepository` uses *Eager Loading* (`.Include`) to ensure API responses contain Breed and Size data.
* The `PetService` centralizes the validation of existing related entities, returning clear 404 errors instead of database 500 errors.