### PR TITLE
fix(auth): Block login for unconfirmed email addresses

### DIFF
--- a/API_Banho_Tosa/Application/Auth/Services/AuthService.cs
+++ b/API_Banho_Tosa/Application/Auth/Services/AuthService.cs
@@ -46,6 +46,16 @@ namespace API_Banho_Tosa.Application.Auth.Services
                 throw new UnauthorizedAccessException("Invalid username or password.");
             }
 
+            if (!user.IsEmailConfirmed)
+            {
+                _logger.LogWarning(
+                    "User {UserEmail} tried to login but has not confirmed their email yet.",
+                    user.Email.ToString()
+                );
+
+                throw new UnauthorizedAccessException("Email address not confirmed.");
+            }
+
             return await CreateAndReturnUserToken(user);
         }
 


### PR DESCRIPTION
fix(auth): Block login for unconfirmed email addresses

Adds a verification step in the `LoginAsync` method to ensure that the user has confirmed their email address before issuing a JWT token.

This enforces the registration flow integrity, preventing unverified accounts from accessing protected resources.